### PR TITLE
use 0.6.0-pre as minimum julia version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre


### PR DESCRIPTION
since `struct` syntax wouldn't work on early 0.6.0-dev versions,
the package shouldn't claim to support them