### PR TITLE
WIP Add lifted version of split

### DIFF
--- a/src/DataValues.jl
+++ b/src/DataValues.jl
@@ -10,6 +10,7 @@ export dropna, dropna!, padna!, padna
 include("scalar/core.jl")
 include("scalar/broadcast.jl")
 include("scalar/operations.jl")
+include("scalar/strings.jl")
 
 include("array/typedefs.jl")
 include("array/constructors.jl")

--- a/src/scalar/strings.jl
+++ b/src/scalar/strings.jl
@@ -1,0 +1,15 @@
+function Base.split(str::DataValue{T}) where {T<:AbstractString}
+    if isnull(str)
+        return SubString{T}[]
+    else
+        return split(get(str))
+    end
+end
+
+function Base.split(str::DataValue{T}, splitter; kwargs...) where {T<:AbstractString}
+    if isnull(str)
+        return SubString{T}[]
+    else
+        return split(get(str), splitter; kwargs...)
+    end    
+end


### PR DESCRIPTION
This is probably a horrible idea and most likely I won't merge it. But hey, lets think about it a while. It is the only way that I can think of that would make the last query in https://github.com/davidanthoff/Query.jl/issues/134 work out of the gate without a need to think about missing values... Maybe that goal is mistaken in the first place, though.

Essentially what this would do is treat a missing string passed to ``split`` as equivalent to an empty string...