### PR TITLE
Fix method ambiguity

### DIFF
--- a/src/array/primitives.jl
+++ b/src/array/primitives.jl
@@ -17,6 +17,10 @@ function Base.similar(x::Array, ::Type{DataValue{T}}, dims::Dims) where {T}
     return DataValueArray{T}(dims)
 end
 
+function Base.similar(x::SubArray, ::Type{DataValue{T}}, dims::Dims) where {T}
+    return DataValueArray{T}(dims)
+end
+
 """
     copy(X::DataValueArray)
 


### PR DESCRIPTION
Fixes #36.

@piever I'm not 100% sure this is the right fix, but what you get with this is the following:
````julia
julia> similar(view([DataValue()], 1, 1))
0-dimensional DataValues.DataValueArray{Union{},0}:
#NA
````
Does that look like the right output? Certainly it gets rid of the method ambiguity.